### PR TITLE
Changes in gallery shell and theming

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,13 +8,13 @@
         <!-- Important: keep version in sync! -->
         <PackageVersion Include="Avalonia" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.8" />
+        <PackageVersion Include="Avalonia.Themes.Simple" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Desktop" Version="11.3.8" />
         <PackageVersion Include="Avalonia.iOS" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Browser" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Android" Version="11.3.8" />
-        <PackageVersion Include="Avalonia.Labs.Controls" Version="11.3.1" />
         <PackageVersion Include="Avalonia.Headless" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.8" />
         <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.3.8" />

--- a/src/Nova.Avalonia.UI.Gallery/App.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/App.axaml
@@ -1,7 +1,6 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:Nova.Avalonia.UI.Gallery"
-             xmlns:labs="using:Avalonia.Labs.Controls"
              x:Class="Nova.Avalonia.UI.Gallery.App"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
@@ -12,18 +11,23 @@
 
     <Application.Styles>
         <FluentTheme />
-        <labs:ControlThemes />
         <StyleInclude Source="avares://Nova.Avalonia.UI/Themes/Controls.axaml" />
+        <StyleInclude Source="avares://Nova.Avalonia.UI.Gallery/Styles/NovaShellStyles.axaml" />
     </Application.Styles>
 
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceInclude Source="avares://Nova.Avalonia.UI.BarcodeGenerator/Themes/BarcodeGenerator.axaml" />
+                <ResourceInclude Source="avares://Nova.Avalonia.UI.Gallery/Styles/NovaTokens.axaml" />
+                <ResourceInclude Source="avares://Nova.Avalonia.UI.Gallery/Styles/GalleryStyles.axaml" />
             </ResourceDictionary.MergedDictionaries>
             
-            <SolidColorBrush x:Key="AccentBrush" Color="{DynamicResource SystemAccentColor}" />
-            <SolidColorBrush x:Key="AccentMutedBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.75" />
+            <!-- Compatibility aliases for existing samples. -->
+            <SolidColorBrush x:Key="AccentBrush" Color="{DynamicResource NovaAccentColor}" />
+            <SolidColorBrush x:Key="SecondaryTextBrush" Color="{DynamicResource NovaInk2Color}" />
+            <SolidColorBrush x:Key="CardBorderBrush" Color="{DynamicResource NovaLineColor}" />
+            <SolidColorBrush x:Key="CardBackgroundBrush" Color="{DynamicResource NovaSurfaceColor}" />
 
             <!-- Shared Barcode brushes (High Contrast for both themes) -->
             <!-- We use standard "Dark Bars on Light Background" for barcodes even in Dark Mode -->
@@ -49,18 +53,6 @@
             <SolidColorBrush x:Key="BarcodeGrayBrush" Color="#37474F" />
             <SolidColorBrush x:Key="BarcodeGrayBackgroundBrush" Color="#ECEFF1" />
 
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light">
-                    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#666666" />
-                    <SolidColorBrush x:Key="CardBorderBrush" Color="#33000000" />
-                    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#0F000000" />
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#CCDDDDDD" />
-                    <SolidColorBrush x:Key="CardBorderBrush" Color="#33FFFFFF" />
-                    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#19FFFFFF" />
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Application.Resources>
 

--- a/src/Nova.Avalonia.UI.Gallery/App.axaml.cs
+++ b/src/Nova.Avalonia.UI.Gallery/App.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
 using System.Linq;
 using Avalonia.Markup.Xaml;
+using Avalonia.Themes.Fluent;
+using Avalonia.Themes.Simple;
 using Nova.Avalonia.UI.Gallery.ViewModels;
 using Nova.Avalonia.UI.Gallery.Views;
 
@@ -11,6 +13,23 @@ namespace Nova.Avalonia.UI.Gallery;
 
 public partial class App : Application
 {
+    public static bool SetBaseTheme(bool useSimple)
+    {
+        if (Current is not { } application || application.Styles.Count == 0)
+        {
+            return false;
+        }
+
+        var isSimple = application.Styles[0] is SimpleTheme;
+        if (isSimple == useSimple)
+        {
+            return false;
+        }
+
+        application.Styles[0] = useSimple ? new SimpleTheme() : new FluentTheme();
+        return true;
+    }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Nova.Avalonia.UI.Gallery/Nova.Avalonia.UI.Gallery.csproj
+++ b/src/Nova.Avalonia.UI.Gallery/Nova.Avalonia.UI.Gallery.csproj
@@ -13,8 +13,8 @@
     <ItemGroup>
         <PackageReference Include="Avalonia"/>
         <PackageReference Include="Avalonia.Themes.Fluent"/>
+        <PackageReference Include="Avalonia.Themes.Simple"/>
         <PackageReference Include="Avalonia.Fonts.Inter"/>
-        <PackageReference Include="Avalonia.Labs.Controls" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/src/Nova.Avalonia.UI.Gallery/Styles/GalleryStyles.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Styles/GalleryStyles.axaml
@@ -1,0 +1,78 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <StreamGeometry x:Key="GallerySettingsGeometry">M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z</StreamGeometry>
+
+    <ControlTheme x:Key="NovaChoiceChip" TargetType="RadioButton">
+        <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+        <Setter Property="FontSize" Value="11.5" />
+        <Setter Property="Height" Value="24" />
+        <Setter Property="Margin" Value="0,0,4,4" />
+        <Setter Property="Padding" Value="9,0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Name="PART_Chip"
+                        Background="{DynamicResource NovaFieldBrush}"
+                        BorderBrush="Transparent"
+                        BorderThickness="1"
+                        CornerRadius="6"
+                        Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center" />
+                </Border>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+        </Style>
+        <Style Selector="^:checked">
+            <Setter Property="Foreground" Value="{DynamicResource NovaAccentBrush}" />
+            <Style Selector="^ /template/ Border#PART_Chip">
+                <Setter Property="Background" Value="{DynamicResource NovaAccentTintBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource NovaAccentBrush}" />
+            </Style>
+        </Style>
+        <Style Selector="^:focus-visible /template/ Border#PART_Chip">
+            <Setter Property="BorderBrush" Value="{DynamicResource NovaAccentBrush}" />
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme x:Key="NovaIconButton" TargetType="Button">
+        <Setter Property="Width" Value="24" />
+        <Setter Property="Height" Value="24" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Name="PART_IconBorder"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        BorderThickness="1"
+                        CornerRadius="6">
+                    <Viewbox Width="15" Height="15"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center">
+                        <Canvas Width="24" Height="24">
+                            <Path Data="{TemplateBinding Tag}"
+                                  Stroke="{TemplateBinding Foreground}"
+                                  StrokeJoin="Round"
+                                  StrokeLineCap="Round"
+                                  StrokeThickness="1.8" />
+                        </Canvas>
+                    </Viewbox>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+        </Style>
+        <Style Selector="^:pointerover /template/ Border#PART_IconBorder">
+            <Setter Property="Background" Value="{DynamicResource NovaHoverStrongBrush}" />
+        </Style>
+        <Style Selector="^:focus-visible /template/ Border#PART_IconBorder">
+            <Setter Property="BorderBrush" Value="{DynamicResource NovaAccentBrush}" />
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/Nova.Avalonia.UI.Gallery/Styles/NovaShellStyles.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Styles/NovaShellStyles.axaml
@@ -1,0 +1,229 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <!-- The shared Nova shell: type ramp, section labels, nav pills, and catalogue cards.
+       This file is copied verbatim into every Nova gallery. Edit one copy, then recopy to the
+       others so the md5s stay identical; do not let a copy diverge. -->
+
+  <!-- Sidebar header -->
+  <Style Selector="TextBlock.wordmark">
+    <Setter Property="FontSize" Value="14.5" />
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="LetterSpacing" Value="-0.2" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="TextBlock.tagline">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+  </Style>
+
+  <!-- Sidebar footer -->
+  <Style Selector="TextBlock.footername">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+  </Style>
+  <Style Selector="TextBlock.footerblurb">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+  </Style>
+
+  <!-- Page header: eyebrow (catalog number), title, intro. -->
+  <Style Selector="TextBlock.eyebrow">
+    <Setter Property="FontFamily" Value="{DynamicResource NovaFontFamilyMono}" />
+    <Setter Property="FontSize" Value="11" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+  </Style>
+  <Style Selector="TextBlock.title">
+    <Setter Property="FontSize" Value="30" />
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="LetterSpacing" Value="-0.5" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="TextBlock.sub">
+    <Setter Property="FontSize" Value="14.5" />
+    <Setter Property="LineHeight" Value="22" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="MaxWidth" Value="700" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+  </Style>
+
+  <!-- Home hero -->
+  <Style Selector="TextBlock.hero">
+    <Setter Property="FontSize" Value="30" />
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="LetterSpacing" Value="-0.5" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="TextBlock.herotagline">
+    <Setter Property="FontSize" Value="14.5" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+  </Style>
+  <Style Selector="TextBlock.blurb">
+    <Setter Property="FontSize" Value="13" />
+    <Setter Property="LineHeight" Value="20" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="MaxWidth" Value="560" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+  </Style>
+
+  <!-- Section labels -->
+  <Style Selector="TextBlock.navgroup">
+    <Setter Property="FontSize" Value="10.5" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="LetterSpacing" Value="1.2" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+    <Setter Property="Margin" Value="13,18,0,6" />
+  </Style>
+  <Style Selector="TextBlock.settings-label">
+    <Setter Property="FontSize" Value="10.5" />
+    <Setter Property="FontWeight" Value="Medium" />
+    <Setter Property="LetterSpacing" Value="0.6" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+  </Style>
+
+  <!-- Sample stage: the quiet well every demo sits in, per the AIKit reference. -->
+  <Style Selector="Border.stage">
+    <Setter Property="Background" Value="{DynamicResource NovaCanvasBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource NovaLineBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="{DynamicResource NovaWindowCornerRadius}" />
+    <Setter Property="ClipToBounds" Value="True" />
+  </Style>
+
+  <!-- Section label inside pages: the caps treatment without the sidebar margins. -->
+  <Style Selector="TextBlock.sectionlabel">
+    <Setter Property="FontSize" Value="10.5" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="LetterSpacing" Value="1.2" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk3Brush}" />
+  </Style>
+
+  <!-- Stat chips -->
+  <Style Selector="Border.chip">
+    <Setter Property="Background" Value="{DynamicResource NovaFieldBrush}" />
+    <Setter Property="CornerRadius" Value="7" />
+    <Setter Property="Padding" Value="11,5" />
+  </Style>
+  <Style Selector="TextBlock.chipvalue">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="TextBlock.chiplabel">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+  </Style>
+
+  <!-- Catalogue card text -->
+  <Style Selector="TextBlock.cardtitle">
+    <Setter Property="FontSize" Value="13.5" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="TextBlock.carddesc">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="LineHeight" Value="17" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+  </Style>
+
+  <!-- Sidebar nav lists: hover is a wash, selection is the accent pill. -->
+  <Style Selector="ListBox.nav">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Padding" Value="0" />
+  </Style>
+  <Style Selector="ListBox.nav ListBoxItem">
+    <Setter Property="MinHeight" Value="0" />
+    <Setter Property="Padding" Value="13,9" />
+    <Setter Property="Margin" Value="0,1" />
+    <Setter Property="CornerRadius" Value="9" />
+    <Setter Property="FontSize" Value="13.5" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <Style Selector="ListBox.nav ListBoxItem:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaHoverBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="ListBox.nav ListBoxItem:selected /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaAccentTintBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource NovaAccentBrush}" />
+  </Style>
+  <Style Selector="ListBox.nav ListBoxItem:selected:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaHoverStrongBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource NovaAccentBrush}" />
+  </Style>
+  <Style Selector="ListBox.nav ListBoxItem:selected">
+    <Setter Property="FontWeight" Value="SemiBold" />
+  </Style>
+
+  <!-- Home is a Button rather than a list item, so it needs the nav item look spelled out. -->
+  <Style Selector="Button.navhome">
+    <Setter Property="Padding" Value="13,9" />
+    <Setter Property="Margin" Value="0,1" />
+    <Setter Property="CornerRadius" Value="9" />
+    <Setter Property="FontSize" Value="13.5" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Foreground" Value="{DynamicResource NovaInk2Brush}" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <Style Selector="Button.navhome:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaHoverBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource NovaInkBrush}" />
+  </Style>
+  <Style Selector="Button.navhome.active">
+    <Setter Property="FontWeight" Value="SemiBold" />
+  </Style>
+  <Style Selector="Button.navhome.active /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaAccentTintBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource NovaAccentBrush}" />
+  </Style>
+  <Style Selector="Button.navhome.active:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaHoverStrongBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource NovaAccentBrush}" />
+  </Style>
+
+  <!-- Catalogue cards and rows -->
+  <Style Selector="Button.samplecard">
+    <Setter Property="Background" Value="{DynamicResource NovaSurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource NovaLineBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="Padding" Value="16,13" />
+    <Setter Property="Margin" Value="0,0,10,10" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <Style Selector="Button.samplecard:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaInsetBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource NovaLineStrongBrush}" />
+  </Style>
+  <Style Selector="Button.samplecard:pressed /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaInsetBrush}" />
+  </Style>
+
+  <Style Selector="Button.homerow">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="CornerRadius" Value="9" />
+    <Setter Property="Padding" Value="13,8" />
+    <Setter Property="Margin" Value="0,1" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <Style Selector="Button.homerow:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource NovaHoverBrush}" />
+  </Style>
+
+</Styles>

--- a/src/Nova.Avalonia.UI.Gallery/Styles/NovaTokens.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Styles/NovaTokens.axaml
@@ -1,0 +1,121 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Canonical Nova palette shared by the Nova galleries. -->
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <Color x:Key="NovaPageColor">#FAFAFB</Color>
+            <Color x:Key="NovaCanvasColor">#F1F2F3</Color>
+            <Color x:Key="NovaSurfaceColor">#FFFFFF</Color>
+            <Color x:Key="NovaInsetColor">#F7F8F9</Color>
+            <Color x:Key="NovaHoverColor">#F4F5F6</Color>
+            <Color x:Key="NovaHoverStrongColor">#E7E9EB</Color>
+            <Color x:Key="NovaInkColor">#1F2124</Color>
+            <Color x:Key="NovaInk2Color">#62656B</Color>
+            <Color x:Key="NovaInk3Color">#6C7076</Color>
+            <Color x:Key="NovaLineColor">#ECEDEF</Color>
+            <Color x:Key="NovaLineStrongColor">#E0E2E5</Color>
+            <Color x:Key="NovaFieldColor">#F2F2F3</Color>
+            <Color x:Key="NovaAccentColor">#0285FF</Color>
+            <Color x:Key="NovaAccentInkColor">#0170DD</Color>
+            <Color x:Key="NovaOnAccentColor">#FFFFFF</Color>
+            <Color x:Key="NovaAccentTintColor">#E9F3FF</Color>
+            <Color x:Key="NovaGreenColor">#189A4D</Color>
+            <Color x:Key="NovaGreenTintColor">#E8F5ED</Color>
+            <Color x:Key="NovaOrangeColor">#EF720C</Color>
+            <Color x:Key="NovaOrangeTintColor">#FDF1E5</Color>
+            <Color x:Key="NovaRedColor">#E3474C</Color>
+            <Color x:Key="NovaRedTintColor">#FCECEC</Color>
+            <Color x:Key="NovaChipBackgroundColor">#E7E9EB</Color>
+            <Color x:Key="NovaChipHoverBackgroundColor">#E0E2E5</Color>
+            <Color x:Key="NovaChipForegroundColor">#43464C</Color>
+
+            <SolidColorBrush x:Key="NovaPageBrush" Color="{StaticResource NovaPageColor}" />
+            <SolidColorBrush x:Key="NovaCanvasBrush" Color="{StaticResource NovaCanvasColor}" />
+            <SolidColorBrush x:Key="NovaSurfaceBrush" Color="{StaticResource NovaSurfaceColor}" />
+            <SolidColorBrush x:Key="NovaInsetBrush" Color="{StaticResource NovaInsetColor}" />
+            <SolidColorBrush x:Key="NovaHoverBrush" Color="{StaticResource NovaHoverColor}" />
+            <SolidColorBrush x:Key="NovaHoverStrongBrush" Color="{StaticResource NovaHoverStrongColor}" />
+            <SolidColorBrush x:Key="NovaInkBrush" Color="{StaticResource NovaInkColor}" />
+            <SolidColorBrush x:Key="NovaInk2Brush" Color="{StaticResource NovaInk2Color}" />
+            <SolidColorBrush x:Key="NovaInk3Brush" Color="{StaticResource NovaInk3Color}" />
+            <SolidColorBrush x:Key="NovaLineBrush" Color="{StaticResource NovaLineColor}" />
+            <SolidColorBrush x:Key="NovaLineStrongBrush" Color="{StaticResource NovaLineStrongColor}" />
+            <SolidColorBrush x:Key="NovaFieldBrush" Color="{StaticResource NovaFieldColor}" />
+            <SolidColorBrush x:Key="NovaAccentBrush" Color="{StaticResource NovaAccentColor}" />
+            <SolidColorBrush x:Key="NovaAccentInkBrush" Color="{StaticResource NovaAccentInkColor}" />
+            <SolidColorBrush x:Key="NovaOnAccentBrush" Color="{StaticResource NovaOnAccentColor}" />
+            <SolidColorBrush x:Key="NovaAccentTintBrush" Color="{StaticResource NovaAccentTintColor}" />
+            <SolidColorBrush x:Key="NovaGreenBrush" Color="{StaticResource NovaGreenColor}" />
+            <SolidColorBrush x:Key="NovaGreenTintBrush" Color="{StaticResource NovaGreenTintColor}" />
+            <SolidColorBrush x:Key="NovaOrangeBrush" Color="{StaticResource NovaOrangeColor}" />
+            <SolidColorBrush x:Key="NovaOrangeTintBrush" Color="{StaticResource NovaOrangeTintColor}" />
+            <SolidColorBrush x:Key="NovaRedBrush" Color="{StaticResource NovaRedColor}" />
+            <SolidColorBrush x:Key="NovaRedTintBrush" Color="{StaticResource NovaRedTintColor}" />
+            <SolidColorBrush x:Key="NovaChipBackgroundBrush" Color="{StaticResource NovaChipBackgroundColor}" />
+            <SolidColorBrush x:Key="NovaChipHoverBackgroundBrush" Color="{StaticResource NovaChipHoverBackgroundColor}" />
+            <SolidColorBrush x:Key="NovaChipForegroundBrush" Color="{StaticResource NovaChipForegroundColor}" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Dark">
+            <Color x:Key="NovaPageColor">#17181A</Color>
+            <Color x:Key="NovaCanvasColor">#1C1D1F</Color>
+            <Color x:Key="NovaSurfaceColor">#232427</Color>
+            <Color x:Key="NovaInsetColor">#1F2022</Color>
+            <Color x:Key="NovaHoverColor">#2A2B2E</Color>
+            <Color x:Key="NovaHoverStrongColor">#313236</Color>
+            <Color x:Key="NovaInkColor">#F2F3F4</Color>
+            <Color x:Key="NovaInk2Color">#A5A8AD</Color>
+            <Color x:Key="NovaInk3Color">#A0A4AB</Color>
+            <Color x:Key="NovaLineColor">#2E3033</Color>
+            <Color x:Key="NovaLineStrongColor">#3A3C40</Color>
+            <Color x:Key="NovaFieldColor">#2B2C2F</Color>
+            <Color x:Key="NovaAccentColor">#3D9AFF</Color>
+            <Color x:Key="NovaAccentInkColor">#7EC0FF</Color>
+            <Color x:Key="NovaOnAccentColor">#FFFFFF</Color>
+            <Color x:Key="NovaAccentTintColor">#293D9AFF</Color>
+            <Color x:Key="NovaGreenColor">#3DBB72</Color>
+            <Color x:Key="NovaGreenTintColor">#243DBB72</Color>
+            <Color x:Key="NovaOrangeColor">#F68F3C</Color>
+            <Color x:Key="NovaOrangeTintColor">#24F68F3C</Color>
+            <Color x:Key="NovaRedColor">#EE5C61</Color>
+            <Color x:Key="NovaRedTintColor">#24EE5C61</Color>
+            <Color x:Key="NovaChipBackgroundColor">#2B2C2F</Color>
+            <Color x:Key="NovaChipHoverBackgroundColor">#36373B</Color>
+            <Color x:Key="NovaChipForegroundColor">#A5A8AD</Color>
+
+            <SolidColorBrush x:Key="NovaPageBrush" Color="{StaticResource NovaPageColor}" />
+            <SolidColorBrush x:Key="NovaCanvasBrush" Color="{StaticResource NovaCanvasColor}" />
+            <SolidColorBrush x:Key="NovaSurfaceBrush" Color="{StaticResource NovaSurfaceColor}" />
+            <SolidColorBrush x:Key="NovaInsetBrush" Color="{StaticResource NovaInsetColor}" />
+            <SolidColorBrush x:Key="NovaHoverBrush" Color="{StaticResource NovaHoverColor}" />
+            <SolidColorBrush x:Key="NovaHoverStrongBrush" Color="{StaticResource NovaHoverStrongColor}" />
+            <SolidColorBrush x:Key="NovaInkBrush" Color="{StaticResource NovaInkColor}" />
+            <SolidColorBrush x:Key="NovaInk2Brush" Color="{StaticResource NovaInk2Color}" />
+            <SolidColorBrush x:Key="NovaInk3Brush" Color="{StaticResource NovaInk3Color}" />
+            <SolidColorBrush x:Key="NovaLineBrush" Color="{StaticResource NovaLineColor}" />
+            <SolidColorBrush x:Key="NovaLineStrongBrush" Color="{StaticResource NovaLineStrongColor}" />
+            <SolidColorBrush x:Key="NovaFieldBrush" Color="{StaticResource NovaFieldColor}" />
+            <SolidColorBrush x:Key="NovaAccentBrush" Color="{StaticResource NovaAccentColor}" />
+            <SolidColorBrush x:Key="NovaAccentInkBrush" Color="{StaticResource NovaAccentInkColor}" />
+            <SolidColorBrush x:Key="NovaOnAccentBrush" Color="{StaticResource NovaOnAccentColor}" />
+            <SolidColorBrush x:Key="NovaAccentTintBrush" Color="{StaticResource NovaAccentTintColor}" />
+            <SolidColorBrush x:Key="NovaGreenBrush" Color="{StaticResource NovaGreenColor}" />
+            <SolidColorBrush x:Key="NovaGreenTintBrush" Color="{StaticResource NovaGreenTintColor}" />
+            <SolidColorBrush x:Key="NovaOrangeBrush" Color="{StaticResource NovaOrangeColor}" />
+            <SolidColorBrush x:Key="NovaOrangeTintBrush" Color="{StaticResource NovaOrangeTintColor}" />
+            <SolidColorBrush x:Key="NovaRedBrush" Color="{StaticResource NovaRedColor}" />
+            <SolidColorBrush x:Key="NovaRedTintBrush" Color="{StaticResource NovaRedTintColor}" />
+            <SolidColorBrush x:Key="NovaChipBackgroundBrush" Color="{StaticResource NovaChipBackgroundColor}" />
+            <SolidColorBrush x:Key="NovaChipHoverBackgroundBrush" Color="{StaticResource NovaChipHoverBackgroundColor}" />
+            <SolidColorBrush x:Key="NovaChipForegroundBrush" Color="{StaticResource NovaChipForegroundColor}" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <CornerRadius x:Key="NovaWindowCornerRadius">14</CornerRadius>
+    <CornerRadius x:Key="NovaCardCornerRadius">10</CornerRadius>
+    <CornerRadius x:Key="NovaControlCornerRadius">8</CornerRadius>
+    <BoxShadows x:Key="NovaCardShadow">0 1 2 0 #14101828, 0 2 6 0 #0F101828</BoxShadows>
+    <BoxShadows x:Key="NovaPopupShadow">0 4 16 0 #33000000</BoxShadows>
+    <FontFamily x:Key="NovaFontFamilyMono">Menlo, Consolas, Courier New</FontFamily>
+</ResourceDictionary>

--- a/src/Nova.Avalonia.UI.Gallery/ViewModels/HomeViewModel.cs
+++ b/src/Nova.Avalonia.UI.Gallery/ViewModels/HomeViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Nova.Avalonia.UI.Gallery.ViewModels;
+
+public sealed class HomeViewModel : PageViewModel
+{
+    public HomeViewModel() : base("Nova.Avalonia.UI")
+    {
+    }
+}

--- a/src/Nova.Avalonia.UI.Gallery/ViewModels/MainViewModel.cs
+++ b/src/Nova.Avalonia.UI.Gallery/ViewModels/MainViewModel.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.ObjectModel;
-using System.Threading.Tasks;
-using Avalonia;
-using Avalonia.Labs.Controls;
-using Avalonia.Styling;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -10,17 +7,12 @@ namespace Nova.Avalonia.UI.Gallery.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
-    [ObservableProperty] private bool? _showNavBar = true;
-    [ObservableProperty] private bool? _showBackButton = false;
+    [ObservableProperty] private PageViewModel _currentPage = new HomeViewModel();
+    [ObservableProperty] private bool _isHome = true;
     [ObservableProperty] private NavigationSample? _selectedSample;
-    private bool _initialNavigated;
-    private bool _isDark;
 
     public MainViewModel()
     {
-        NavigationRouter = new StackNavigationRouter();
-        NavigationRouter.Navigated += OnNavigated;
-
         Categories = new ObservableCollection<SampleCategory>
         {
             new("Controls", new ObservableCollection<NavigationSample>
@@ -57,46 +49,34 @@ public partial class MainViewModel : ViewModelBase
                 new("VirtualizedVariableSizeWrapPanel", new VirtualizedVariableSizeWrapPanelViewModel(), "Virtualized tile grid layout"),
             }),
         };
-
-        // Start on menu hub; initial navigation clears stack once.
-        _initialNavigated = true;
-        _ = NavigationRouter.NavigateToAsync(new NavigationMenuViewModel(), NavigationMode.Clear);
     }
 
     public ObservableCollection<SampleCategory> Categories { get; }
 
-    public INavigationRouter NavigationRouter { get; }
+    public int SampleCount => Categories.Sum(category => category.Samples.Count);
 
     partial void OnSelectedSampleChanged(NavigationSample? value)
     {
-        _ = NavigateToAsync(value);
-    }
-
-    [RelayCommand]
-    private Task NavigateTo(NavigationSample? sample) => NavigateToAsync(sample);
-
-    [RelayCommand]
-    private void SwapTheme()
-    {
-        _isDark = !_isDark;
-        Application.Current!.RequestedThemeVariant = _isDark ? ThemeVariant.Dark : ThemeVariant.Light;
-    }
-
-    private async Task NavigateToAsync(NavigationSample? sample)
-    {
-        if (sample?.Page is null)
+        if (value?.Page is null)
         {
             return;
         }
 
-        var mode = _initialNavigated ? NavigationMode.Normal : NavigationMode.Clear;
-        _initialNavigated = true;
-
-        await NavigationRouter.NavigateToAsync(sample.Page, mode);
+        CurrentPage = value.Page;
+        IsHome = false;
     }
 
-    private void OnNavigated(object? sender, NavigatedEventArgs e)
+    [RelayCommand]
+    private void NavigateTo(NavigationSample? sample)
     {
-        ShowBackButton = NavigationRouter.CanGoBack;
+        SelectedSample = sample;
+    }
+
+    [RelayCommand]
+    private void GoHome()
+    {
+        SelectedSample = null;
+        CurrentPage = new HomeViewModel();
+        IsHome = true;
     }
 }

--- a/src/Nova.Avalonia.UI.Gallery/Views/ArcPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/ArcPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A layout panel that arranges items along an arc (partial circle)." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage - Semi Circle" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items distributed along a 180° arc starting from the top." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -31,7 +31,7 @@
             </Border>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -67,7 +67,7 @@
             </Border>
 
             <!-- Quarter Arc -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Quarter Arc" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="90° sweep for corner menus or gauges." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -82,7 +82,7 @@
                 </StackPanel>
             </Border>
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the arc layout reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/AutoLayoutView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/AutoLayoutView.axaml
@@ -14,7 +14,7 @@
                        Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Interactive Playground -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
 
@@ -113,7 +113,7 @@
             </Border>
             
             <!-- Reference to Figma -->
-             <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+             <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Absolute Positioning" FontWeight="Bold"/>
                     <TextBlock Text="Items with IsAbsolute=True are removed from flow." Opacity="0.6"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/AvatarView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/AvatarView.axaml
@@ -23,7 +23,7 @@
             <TextBlock Text="A control that represents a user with an image, initials, or icon." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Avatars with Auto Mode -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Avatars"
                                FontSize="16"
@@ -77,7 +77,7 @@
             </Border>
 
             <!-- Different Sizes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Sizes"
                                FontSize="16"
@@ -122,7 +122,7 @@
             </Border>
 
             <!-- Different Shapes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Shapes"
                                FontSize="16"
@@ -156,7 +156,7 @@
             </Border>
 
             <!-- Status Indicators -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Status Indicators"
                                FontSize="16"
@@ -204,7 +204,7 @@
             </Border>
 
             <!-- Custom Colors -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Custom Colors"
                                FontSize="16"
@@ -243,7 +243,7 @@
             </Border>
 
             <!-- Auto-Generated Colors -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Auto-Generated Colors (name hash)"
                                FontSize="16"
@@ -263,7 +263,7 @@
             </Border>
 
             <!-- Display Modes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Display Modes"
                                FontSize="16"
@@ -305,7 +305,7 @@
             </Border>
 
             <!-- Avatar Group -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Avatar Group"
                                FontSize="16"
@@ -344,7 +344,7 @@
             </Border>
 
             <!-- Styled Variants -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Styled Variants"
                                FontSize="16"
@@ -377,7 +377,7 @@
             </Border>
 
             <!-- Real-World Example -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Real-World Example"
                                FontSize="16"

--- a/src/Nova.Avalonia.UI.Gallery/Views/BadgeView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/BadgeView.axaml
@@ -11,7 +11,7 @@
             <TextBlock Text="A notification badge for displaying counts or status indicators." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Badges (Standalone) -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Badges"
                                FontSize="16"
@@ -54,7 +54,7 @@
             </Border>
 
             <!-- Outline Badges -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Outline Badges"
                                FontSize="16"
@@ -82,7 +82,7 @@
             </Border>
 
             <!-- Sizes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Different Sizes"
                                FontSize="16"
@@ -105,7 +105,7 @@
             </Border>
 
             <!-- Number Badges -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Number Badges"
                                FontSize="16"
@@ -136,7 +136,7 @@
             </Border>
 
             <!-- Dot Indicators -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dot Indicators"
                                FontSize="16"
@@ -171,7 +171,7 @@
             </Border>
 
             <!-- All Placements -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="All Placements"
                                FontSize="16"
@@ -263,7 +263,7 @@
             </Border>
 
             <!-- Badges on Buttons -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Badges on Buttons"
                                FontSize="16"
@@ -288,7 +288,7 @@
             </Border>
 
             <!-- Shape Variants -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Shape Variants"
                                FontSize="16"
@@ -311,7 +311,7 @@
             </Border>
 
             <!-- Interactive -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground"
                                FontSize="16"
@@ -340,7 +340,7 @@
             </Border>
             
             <!-- Max Count & Cutout Effect -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Max Count &amp; Cutout Effect"
                                FontSize="16"

--- a/src/Nova.Avalonia.UI.Gallery/Views/BarcodeGeneratorView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/BarcodeGeneratorView.axaml
@@ -10,7 +10,7 @@
             <TextBlock Text="A control that generates various 1D and 2D barcodes (QR, Code128, etc)." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic QR Code -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic QR Code" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Standard QR code with text display. Adapts to theme automatically." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -27,7 +27,7 @@
             </Border>
 
             <!-- Custom Colors QR -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Custom Colors" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="QR code with theme-aware custom colors." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -67,7 +67,7 @@
             </Border>
 
             <!-- Code 128 -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Code 128" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Linear barcode commonly used in shipping and logistics." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -84,7 +84,7 @@
             </Border>
 
             <!-- Code 39 -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Code 39" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Alphanumeric barcode used in automotive and defense industries." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -101,7 +101,7 @@
             </Border>
 
             <!-- EAN Barcodes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="EAN Barcodes" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="European Article Number barcodes for retail products." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -132,7 +132,7 @@
             </Border>
 
             <!-- UPC-A -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="UPC-A" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Universal Product Code used in North America." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -148,7 +148,7 @@
             </Border>
 
             <!-- Data Matrix -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Data Matrix" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="2D matrix barcode for small items and electronic components." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -163,7 +163,7 @@
             </Border>
 
             <!-- PDF417 -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="PDF417" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="2D stacked linear format with high data capacity." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -179,7 +179,7 @@
             </Border>
 
             <!-- Aztec -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Aztec Code" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="2D matrix barcode used in transport tickets and boarding passes." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -195,7 +195,7 @@
             </Border>
 
             <!-- ITF -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="ITF (Interleaved 2 of 5)" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Numeric barcode used in logistics and shipping." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -211,7 +211,7 @@
             </Border>
 
             <!-- Code 93 and Codabar -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Other Linear Barcodes" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Code 93 and Codabar formats." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -242,7 +242,7 @@
             </Border>
 
             <!-- Error Correction Levels -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Error Correction Levels" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Higher levels allow more damage recovery but reduce data capacity." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -292,7 +292,7 @@
             </Border>
 
             <!-- Multiple Symbologies Comparison -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Symbology Comparison" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Side-by-side comparison of different barcode types." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -329,7 +329,7 @@
             </Border>
 
             <!-- Sizes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Different Sizes" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="QR codes at various dimensions." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -366,7 +366,7 @@
             </Border>
 
             <!-- QR Code with Logo -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="QR Code with Logo" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Embed a logo in the center of QR codes. Use ErrorCorrectionLevel H for best results." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -407,7 +407,7 @@
             </Border>
 
             <!-- Disabled State -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Disabled State" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Barcode with IsEnabled=False." Foreground="{DynamicResource SecondaryTextBrush}" />

--- a/src/Nova.Avalonia.UI.Gallery/Views/BubblePanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/BubblePanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A panel that packs circular items using circle packing algorithm." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items pack together with larger items placed first." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -49,7 +49,7 @@
             </Border>
 
             <!-- Tag Cloud Style -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Tag Cloud Style" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Different sizes represent importance or frequency." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -80,7 +80,7 @@
             </Border>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -105,7 +105,7 @@
                 </StackPanel>
             </Border>
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see bubble packing reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/CircularPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/CircularPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A layout panel that arranges items in a circular pattern." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items are automatically distributed around a circle." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -32,7 +32,7 @@
             </Border>
 
             <!-- Layout Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Adjust Radius, StartAngle, and Orientation dynamically." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -74,7 +74,7 @@
             </Border>
 
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the layout reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -106,7 +106,7 @@
             </Border>
 
             <!-- Clock Example -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Clock Layout" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="StartAngle=-90 positions 12 at the top." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/CompareSliderView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/CompareSliderView.axaml
@@ -13,7 +13,7 @@
         <StackPanel Spacing="20">
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Side-by-side image comparison." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -30,7 +30,7 @@
             </Border>
 
             <!-- Vertical Orientation (Image Comparison) -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Vertical Orientation" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Compare content vertically (e.g., photo editing effects)." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -51,7 +51,7 @@
             </Border>
             
             <!-- Interactive Control -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Interactive Control" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Control the slider programmatically." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -79,7 +79,7 @@
             </Border>
 
             <!-- Text/Code Comparison -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Content Comparison" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Compare arbitrary content, like code diffs." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -125,7 +125,7 @@
             </Border>
             
             <!-- Custom Styling -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Custom Styling" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Customizing the divider and thumb using inline styles." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -160,7 +160,7 @@
             </Border>
 
             <!-- Custom Range Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Custom Range Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Map values to a specific domain (e.g., timeline progression)." Foreground="{DynamicResource SecondaryTextBrush}" />

--- a/src/Nova.Avalonia.UI.Gallery/Views/FortuneView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/FortuneView.axaml
@@ -86,7 +86,7 @@
                        TextWrapping="Wrap"/>
 
             <!-- Basic FortuneWheel -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Fortune Wheel" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="A circular spin-to-win wheel. Click the button to spin!" Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -115,7 +115,7 @@
             </Border>
 
             <!-- Style Strategies -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Style Strategies" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Different color strategies: Alternating vs Gradient." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -151,7 +151,7 @@
             </Border>
 
             <!-- Indicator Positions -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Indicator Positions" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="The pointer can be positioned at any edge." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -193,7 +193,7 @@
             </Border>
 
             <!-- FortuneBar Horizontal -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Fortune Bar (Horizontal)" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="A slot machine style scrolling bar." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -227,7 +227,7 @@
             </Border>
 
             <!-- FortuneBar Image -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Fortune Bar (Image)" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Slot machine with image assets." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -261,7 +261,7 @@
             </Border>
 
             <!-- FortuneBar Vertical -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Fortune Bar (Vertical)" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Vertical orientation for different layouts." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -295,7 +295,7 @@
             </Border>
 
             <!-- Events Demo -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Events" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Observe SpinStarted and SpinCompleted events." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -335,7 +335,7 @@
             </Border>
 
             <!-- Customization -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Customization" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Custom center size, indicator colors, and slice colors." Foreground="{DynamicResource SecondaryTextBrush}" />

--- a/src/Nova.Avalonia.UI.Gallery/Views/GravatarView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/GravatarView.axaml
@@ -11,7 +11,7 @@
         <StackPanel Spacing="20" Margin="20">
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage"
                                FontWeight="Bold"
@@ -32,7 +32,7 @@
             </Border>
 
             <!-- Size Variations -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Size Variations"
                                FontWeight="Bold"
@@ -53,7 +53,7 @@
             </Border>
 
             <!-- Consistent Output -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Consistent Output"
                                FontWeight="Bold"
@@ -81,7 +81,7 @@
             </Border>
 
             <!-- Custom Image Override -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Custom Image Override"
                                FontWeight="Bold"
@@ -105,7 +105,7 @@
             </Border>
 
             <!-- Interactive Input -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Interactive Input"
                                FontWeight="Bold"

--- a/src/Nova.Avalonia.UI.Gallery/Views/HexPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/HexPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A layout panel that arranges items in a honeycomb pattern." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items positioned using Row and Column attached properties. Using Ellipses to show circle packing." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -50,7 +50,7 @@
             </Border>
 
             <!-- Layout Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Adjust RowCount, ColumnCount, and Orientation." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -93,7 +93,7 @@
             </Border>
 
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the hex grid reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/HomeView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/HomeView.axaml
@@ -1,0 +1,83 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:Nova.Avalonia.UI.Gallery.ViewModels"
+             xmlns:views="using:Nova.Avalonia.UI.Gallery.Views"
+             mc:Ignorable="d"
+             d:DesignWidth="900"
+             d:DesignHeight="700"
+             x:Class="Nova.Avalonia.UI.Gallery.Views.HomeView"
+             x:DataType="vm:HomeViewModel">
+    <Design.DataContext>
+        <vm:HomeViewModel />
+    </Design.DataContext>
+
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="32,36,32,48"
+                    MaxWidth="960"
+                    HorizontalAlignment="Left">
+            <TextBlock Classes="hero" Text="Nova.Avalonia.UI" />
+            <TextBlock Classes="herotagline"
+                       Margin="0,8,0,0"
+                       Text="Controls and layouts for Avalonia" />
+            <TextBlock Classes="blurb"
+                       Margin="0,14,0,0"
+                       Text="Modern controls and layout primitives for Avalonia applications. Pick a sample from the sidebar, or browse the complete catalogue below." />
+
+            <WrapPanel Margin="0,22,0,0">
+                <Border Classes="chip" Margin="0,0,8,8">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBlock Classes="chipvalue"
+                                   Text="{Binding $parent[views:MainView].((vm:MainViewModel)DataContext).SampleCount}" />
+                        <TextBlock Classes="chiplabel" Text="samples" />
+                    </StackPanel>
+                </Border>
+                <Border Classes="chip" Margin="0,0,8,8">
+                    <TextBlock Classes="chiplabel" Text="Light and dark" />
+                </Border>
+                <Border Classes="chip" Margin="0,0,8,8">
+                    <TextBlock Classes="chiplabel" Text="Fluent and Simple" />
+                </Border>
+            </WrapPanel>
+
+            <TextBlock Classes="navgroup"
+                       Margin="1,26,0,10"
+                       Text="ALL COMPONENTS" />
+
+            <ItemsControl ItemsSource="{Binding $parent[views:MainView].((vm:MainViewModel)DataContext).Categories}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:SampleCategory">
+                        <StackPanel>
+                            <TextBlock Classes="navgroup"
+                                       AutomationProperties.HeadingLevel="2"
+                                       Margin="1,18,0,8"
+                                       Text="{Binding Name}" />
+                            <ItemsControl ItemsSource="{Binding Samples}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <UniformGrid Columns="2" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:NavigationSample">
+                                        <Button Classes="samplecard"
+                                                Command="{Binding $parent[views:MainView].((vm:MainViewModel)DataContext).NavigateToCommand}"
+                                                CommandParameter="{Binding}"
+                                                AutomationProperties.Name="{Binding Title}"
+                                                AutomationProperties.HelpText="{Binding Description}">
+                                            <StackPanel Spacing="5">
+                                                <TextBlock Classes="cardtitle" Text="{Binding Title}" />
+                                                <TextBlock Classes="carddesc" Text="{Binding Description}" />
+                                            </StackPanel>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Nova.Avalonia.UI.Gallery/Views/HomeView.axaml.cs
+++ b/src/Nova.Avalonia.UI.Gallery/Views/HomeView.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace Nova.Avalonia.UI.Gallery.Views;
+
+public partial class HomeView : UserControl
+{
+    public HomeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Nova.Avalonia.UI.Gallery/Views/LoopPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/LoopPanelView.axaml
@@ -12,7 +12,7 @@
       <TextBlock Text="A panel that provides infinite scrolling capabilities for its items." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
       <!-- Basic Usage Section -->
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="15">
           <TextBlock Text="Basic Usage" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
           <TextBlock Text="Drag or scroll to navigate infinitely through items." TextWrapping="Wrap" Opacity="0.7" />
@@ -47,7 +47,7 @@
       </Border>
 
       <!-- Vertical Orientation -->
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="15">
           <TextBlock Text="Vertical Orientation" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
 
@@ -75,7 +75,7 @@
       </Border>
 
       <!-- Spacing and Anchor -->
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="15">
           <TextBlock Text="Spacing and Anchor Position" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
           <TextBlock Text="AnchorPosition=0.0 (items anchor at left edge), Spacing=20" TextWrapping="Wrap" Opacity="0.7" />
@@ -104,7 +104,7 @@
       </Border>
 
       <!-- Dynamic Items -->
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="15">
           <TextBlock Text="Dynamic Items" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
           <TextBlock Text="Add or remove items dynamically at runtime." TextWrapping="Wrap" Opacity="0.7" />
@@ -130,7 +130,7 @@
       </Border>
 
       <!-- Programmatic Control -->
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="15">
           <TextBlock Text="Programmatic Scrolling" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
           <TextBlock Text="Use buttons to scroll programmatically via ScrollBy and ScrollToIndex methods." TextWrapping="Wrap" Opacity="0.7" />
@@ -177,7 +177,7 @@
       </Border>
 
       <!-- Interactive Playground -->
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="15">
           <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
 

--- a/src/Nova.Avalonia.UI.Gallery/Views/MainView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/MainView.axaml
@@ -5,47 +5,163 @@
              xmlns:vm="using:Nova.Avalonia.UI.Gallery.ViewModels"
              xmlns:local="using:Nova.Avalonia.UI.Gallery"
              xmlns:views="using:Nova.Avalonia.UI.Gallery.Views"
-             xmlns:labs="clr-namespace:Avalonia.Labs.Controls;assembly=Avalonia.Labs.Controls"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
              x:Class="Nova.Avalonia.UI.Gallery.Views.MainView"
-             x:DataType="vm:MainViewModel">
+             x:DataType="vm:MainViewModel"
+             Background="{DynamicResource NovaPageBrush}"
+             FontSize="13">
     <Design.DataContext>
         <vm:MainViewModel />
     </Design.DataContext>
 
-    <labs:NavigationControl x:Name="Nav"
-                            NavigationRouter="{Binding NavigationRouter}"
-                            IsBackButtonVisible="{Binding ShowBackButton}"
-                            IsNavBarVisible="{Binding ShowNavBar}"
-                            Header="{Binding NavigationRouter.CurrentPage}"
-                            Padding="0"
-                            BorderThickness="1"
-                            BorderBrush="#14000000">
-        <labs:NavigationControl.HeaderTemplate>
-            <DataTemplate x:DataType="vm:PageViewModel">
-                <DockPanel>
-                    <Button Command="{Binding $parent[views:MainView].((vm:MainViewModel)DataContext).SwapThemeCommand}"
-                            HorizontalAlignment="Right"
-                            DockPanel.Dock="Right"
-                            Padding="8,6"
-                            CornerRadius="8"
-                            Background="{DynamicResource CardBackgroundBrush}"
-                            BorderBrush="{DynamicResource CardBorderBrush}"
-                            ToolTip.Tip="Toggle theme">
-                        <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-                            <TextBlock Text="Toggle theme"
-                                       FontWeight="SemiBold" />
+    <SplitView x:Name="Shell"
+               DisplayMode="Inline"
+               IsPaneOpen="True"
+               OpenPaneLength="278"
+               PaneBackground="{DynamicResource NovaPageBrush}">
+        <SplitView.Pane>
+            <Border BorderBrush="{DynamicResource NovaLineBrush}"
+                    BorderThickness="0,0,1,0">
+                <Grid Margin="28,30,24,24" RowDefinitions="Auto,Auto,*,Auto">
+                    <DockPanel Grid.Row="0">
+                        <Button x:Name="SettingsButton"
+                                AutomationProperties.Name="Gallery settings"
+                                DockPanel.Dock="Right"
+                                Tag="{StaticResource GallerySettingsGeometry}"
+                                Theme="{StaticResource NovaIconButton}">
+                            <Button.Flyout>
+                                <Flyout Placement="BottomEdgeAlignedRight" ShowMode="Transient">
+                                    <StackPanel Width="196" Spacing="12">
+                                        <StackPanel Spacing="7">
+                                            <TextBlock Classes="settings-label" Text="APPEARANCE" />
+                                            <WrapPanel>
+                                                <RadioButton x:Name="SystemChip"
+                                                             Content="System"
+                                                             GroupName="ThemeVariant"
+                                                             IsCheckedChanged="OnVariantChanged"
+                                                             Tag="System"
+                                                             Theme="{StaticResource NovaChoiceChip}" />
+                                                <RadioButton x:Name="DarkChip"
+                                                             Content="Dark"
+                                                             GroupName="ThemeVariant"
+                                                             IsCheckedChanged="OnVariantChanged"
+                                                             Tag="Dark"
+                                                             Theme="{StaticResource NovaChoiceChip}" />
+                                                <RadioButton x:Name="LightChip"
+                                                             Content="Light"
+                                                             GroupName="ThemeVariant"
+                                                             IsCheckedChanged="OnVariantChanged"
+                                                             Tag="Light"
+                                                             Theme="{StaticResource NovaChoiceChip}" />
+                                            </WrapPanel>
+                                        </StackPanel>
+                                        <StackPanel Spacing="7">
+                                            <TextBlock Classes="settings-label" Text="BASE THEME" />
+                                            <WrapPanel>
+                                                <RadioButton x:Name="FluentChip"
+                                                             Content="Fluent"
+                                                             GroupName="BaseTheme"
+                                                             IsCheckedChanged="OnBaseThemeChanged"
+                                                             Tag="Fluent"
+                                                             Theme="{StaticResource NovaChoiceChip}" />
+                                                <RadioButton x:Name="SimpleChip"
+                                                             Content="Simple"
+                                                             GroupName="BaseTheme"
+                                                             IsCheckedChanged="OnBaseThemeChanged"
+                                                             Tag="Simple"
+                                                             Theme="{StaticResource NovaChoiceChip}" />
+                                            </WrapPanel>
+                                            <TextBlock Classes="tagline"
+                                                       FontSize="11"
+                                                       Text="Nova controls support either base theme."
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+
+                        <StackPanel VerticalAlignment="Center" Spacing="3">
+                            <TextBlock Classes="wordmark" Text="Nova.Avalonia.UI" />
+                            <TextBlock Classes="tagline" Text="Controls and layouts for Avalonia" />
                         </StackPanel>
-                    </Button>
-                    <TextBlock Text="{Binding Title}"
-                               FontSize="18"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center" />
-                </DockPanel>
-            </DataTemplate>
-        </labs:NavigationControl.HeaderTemplate>
-        <labs:NavigationControl.DataTemplates>
-            <local:ViewLocator />
-        </labs:NavigationControl.DataTemplates>
-    </labs:NavigationControl>
+                    </DockPanel>
+
+                    <Button Grid.Row="1"
+                            Classes="navhome"
+                            Classes.active="{Binding IsHome}"
+                            Command="{Binding GoHomeCommand}"
+                            Click="OnNavigationPicked"
+                            Content="Home"
+                            Margin="0,24,0,10" />
+
+                    <ScrollViewer Grid.Row="2"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl ItemsSource="{Binding Categories}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:SampleCategory">
+                                    <StackPanel>
+                                        <TextBlock Classes="navgroup" Text="{Binding Name}" />
+                                        <ListBox Classes="nav"
+                                                 ItemsSource="{Binding Samples}"
+                                                 SelectedItem="{Binding $parent[views:MainView].((vm:MainViewModel)DataContext).SelectedSample, Mode=TwoWay}"
+                                                 SelectionChanged="OnNavigationSelectionChanged">
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:NavigationSample">
+                                                    <TextBlock Text="{Binding Title}" />
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+
+                    <StackPanel Grid.Row="3" Spacing="2" Margin="0,18,0,0">
+                        <TextBlock Classes="footername" Text="Nova.Avalonia.UI" />
+                        <TextBlock Classes="footerblurb"
+                                   Text="Modern controls and layout primitives for Avalonia applications." />
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </SplitView.Pane>
+
+        <Grid>
+            <ContentControl x:Name="PageHost"
+                            Content="{Binding CurrentPage}"
+                            Background="{DynamicResource NovaPageBrush}"
+                            Foreground="{DynamicResource NovaInkBrush}">
+                <ContentControl.DataTemplates>
+                    <local:ViewLocator />
+                </ContentControl.DataTemplates>
+            </ContentControl>
+
+            <Button x:Name="MenuButton"
+                    AutomationProperties.Name="Open navigation"
+                    Click="OnToggleMenu"
+                    IsVisible="False"
+                    ZIndex="10"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Margin="14"
+                    Width="36"
+                    Height="34"
+                    CornerRadius="9"
+                    Background="{DynamicResource NovaSurfaceBrush}"
+                    BorderBrush="{DynamicResource NovaLineBrush}"
+                    BorderThickness="1"
+                    Cursor="Hand">
+                <Viewbox Width="16" Height="16">
+                    <Canvas Width="24" Height="24">
+                        <Path Data="M3 6h18M3 12h18M3 18h18"
+                              Stroke="{DynamicResource NovaInk2Brush}"
+                              StrokeJoin="Round"
+                              StrokeLineCap="Round"
+                              StrokeThickness="2" />
+                    </Canvas>
+                </Viewbox>
+            </Button>
+        </Grid>
+    </SplitView>
 </UserControl>

--- a/src/Nova.Avalonia.UI.Gallery/Views/MainView.axaml.cs
+++ b/src/Nova.Avalonia.UI.Gallery/Views/MainView.axaml.cs
@@ -1,11 +1,103 @@
+using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Interactivity;
+using Avalonia.Styling;
+using Avalonia.Themes.Simple;
 
 namespace Nova.Avalonia.UI.Gallery.Views;
 
 public partial class MainView : UserControl
 {
+    private const double SidebarBreakpoint = 880;
+    private bool _settingsReady;
+
     public MainView()
     {
         InitializeComponent();
+
+        var variant = Application.Current?.RequestedThemeVariant;
+        LightChip.IsChecked = variant == ThemeVariant.Light;
+        DarkChip.IsChecked = variant == ThemeVariant.Dark;
+        SystemChip.IsChecked = variant != ThemeVariant.Light && variant != ThemeVariant.Dark;
+
+        var isSimple = Application.Current?.Styles.FirstOrDefault() is SimpleTheme;
+        SimpleChip.IsChecked = isSimple;
+        FluentChip.IsChecked = !isSimple;
+        _settingsReady = true;
+
+        SizeChanged += (_, e) => UpdateShellLayout(e.NewSize.Width);
+    }
+
+    private void UpdateShellLayout(double width)
+    {
+        var isWide = width >= SidebarBreakpoint;
+        Shell.DisplayMode = isWide ? SplitViewDisplayMode.Inline : SplitViewDisplayMode.Overlay;
+        Shell.IsPaneOpen = isWide;
+        MenuButton.IsVisible = !isWide;
+        PageHost.Margin = isWide ? default : new Thickness(0, 46, 0, 0);
+    }
+
+    private void OnToggleMenu(object? sender, RoutedEventArgs e)
+    {
+        Shell.IsPaneOpen = !Shell.IsPaneOpen;
+    }
+
+    private void OnNavigationPicked(object? sender, RoutedEventArgs e)
+    {
+        CloseOverlayPane();
+    }
+
+    private void OnNavigationSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is ListBox { SelectedItem: not null })
+        {
+            CloseOverlayPane();
+        }
+    }
+
+    private void CloseOverlayPane()
+    {
+        if (Shell.DisplayMode == SplitViewDisplayMode.Overlay)
+        {
+            Shell.IsPaneOpen = false;
+        }
+    }
+
+    private void OnVariantChanged(object? sender, RoutedEventArgs e)
+    {
+        if (!_settingsReady || Application.Current is not { } application ||
+            sender is not RadioButton { IsChecked: true, Tag: string variant })
+        {
+            return;
+        }
+
+        application.RequestedThemeVariant = variant switch
+        {
+            "Light" => ThemeVariant.Light,
+            "Dark" => ThemeVariant.Dark,
+            _ => ThemeVariant.Default,
+        };
+    }
+
+    private void OnBaseThemeChanged(object? sender, RoutedEventArgs e)
+    {
+        if (!_settingsReady || sender is not RadioButton { IsChecked: true, Tag: string baseTheme } ||
+            !App.SetBaseTheme(useSimple: baseTheme == "Simple"))
+        {
+            return;
+        }
+
+        var replacement = new MainView { DataContext = DataContext };
+        switch (Application.Current?.ApplicationLifetime)
+        {
+            case IClassicDesktopStyleApplicationLifetime { MainWindow: { } window }:
+                window.Content = replacement;
+                break;
+            case ISingleViewApplicationLifetime singleView:
+                singleView.MainView = replacement;
+                break;
+        }
     }
 }

--- a/src/Nova.Avalonia.UI.Gallery/Views/OrbitPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/OrbitPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A layout panel that arranges items in concentric orbit rings." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items grouped by Orbit attached property (0=center, 1=first ring, etc.)." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -43,7 +43,7 @@
             </Border>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -79,7 +79,7 @@
                 </StackPanel>
             </Border>
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see orbit layout reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/OverlapPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/OverlapPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A panel that stacks children with configurable X/Y offsets." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items stack with horizontal and vertical offsets." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -38,7 +38,7 @@
             </Border>
 
             <!-- Playground -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Adjust OffsetX, OffsetY, and ReverseZIndex." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -84,7 +84,7 @@
             </Border>
 
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the overlap adjust." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -116,7 +116,7 @@
             </Border>
 
             <!-- Negative Offset Example -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Negative Offsets" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Use negative offsets to stack in the opposite direction." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/RadialPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/RadialPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="Arranges items in a radial pattern radiating from the center." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items radiate outward from the center in a fan pattern." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -44,7 +44,7 @@
             </Border>
 
             <!-- Playground -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Adjust Radius, StartAngle, SweepAngle, and item rotation." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -109,7 +109,7 @@
             </Border>
 
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the radial layout reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -141,7 +141,7 @@
             </Border>
 
             <!-- Half-Circle Example -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Half-Circle Layout" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="SweepAngle=180 creates a semi-circular arrangement." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/RatingControlView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/RatingControlView.axaml
@@ -12,7 +12,7 @@
             <TextBlock Text="A control for collecting or displaying ratings with customizable shapes." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Standard rating control with default settings." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -22,7 +22,7 @@
             </Border>
 
             <!-- Precision Modes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Precision Modes" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Control how values are selected: Full, Half, or Exact." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -45,7 +45,7 @@
             </Border>
 
             <!-- Shapes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Shapes" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Built-in shapes and support for custom geometries." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -83,7 +83,7 @@
             </Border>
 
             <!-- Colors & Styling -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Colors &amp; Styling" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Customize fills, strokes, sizing, and spacing." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -99,7 +99,7 @@
             </Border>
 
             <!-- Read Only -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Read Only" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Display-only mode. Users cannot interact with it." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -109,7 +109,7 @@
             </Border>
 
             <!-- Item Count -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Item Count" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="Support for any number of items." Foreground="{DynamicResource SecondaryTextBrush}" />
@@ -119,7 +119,7 @@
             </Border>
 
             <!-- ValueChanged Event -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="ValueChanged Event" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}" />
                     <TextBlock Text="React to value changes with the ValueChanged event." Foreground="{DynamicResource SecondaryTextBrush}" />

--- a/src/Nova.Avalonia.UI.Gallery/Views/ResponsivePanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/ResponsivePanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="An adaptive layout panel that toggles visibility of children based on breakpoints." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Window Resizing Demo -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                      <TextBlock Text="Window Resizing" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                      <TextBlock Text="Resize the application window to see this panel adapt." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -40,7 +40,7 @@
             </Border>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <Grid ColumnDefinitions="*, Auto">
                         <StackPanel Spacing="5">
@@ -105,7 +105,7 @@
 
             <!-- Interactive - Only visible on tablet and desktop -->
             <nova:ResponsivePanel>
-                <Border nova:ResponsivePanel.Condition="Normal" BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+                <Border Classes="stage" nova:ResponsivePanel.Condition="Normal" Padding="15">
                     <StackPanel Spacing="10">
                         <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                         <TextBlock Text="Use the slider to simulate container width and see the layout adapt. Try different transition effects." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -270,7 +270,7 @@
                     </StackPanel>
                 </Border>
                 
-                <Border nova:ResponsivePanel.Condition="Wide" BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+                <Border Classes="stage" nova:ResponsivePanel.Condition="Wide" Padding="15">
                     <StackPanel Spacing="10">
                         <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                         <TextBlock Text="Use the slider to simulate container width and see the layout adapt. Try different transition effects." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/ScratcherView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/ScratcherView.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="using:Nova.Avalonia.UI.Controls"
              x:Class="Nova.Avalonia.UI.Gallery.Views.ScratcherView">
-    
+
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
@@ -18,22 +18,20 @@
 
     <ScrollViewer>
         <StackPanel Spacing="20" Margin="20">
-            
+
             <!-- Basic Scratcher -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" 
-                    BorderThickness="2" 
-                    Padding="15" 
-                    CornerRadius="8">
+            <Border Classes="stage"
+                    Padding="15">
                 <StackPanel Spacing="15">
-                    <TextBlock Text="Basic Scratcher" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
+                    <TextBlock Text="Basic Scratcher"
+                               FontSize="16"
+                               FontWeight="Bold"
                                Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="Scratch the gray area to reveal the hidden prize!" 
+                    <TextBlock Text="Scratch the gray area to reveal the hidden prize!"
                                Foreground="{DynamicResource SecondaryTextBrush}" />
-                    
+
                     <controls:Scratcher x:Name="BasicScratcher"
-                                        Width="300" 
+                                        Width="300"
                                         Height="150"
                                         OverlayBrush="{DynamicResource ScratcherOverlayBrush}"
                                         BrushSize="40"
@@ -42,19 +40,19 @@
                                         HorizontalAlignment="Left">
                         <Border Background="#FFD700" CornerRadius="8">
                             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <TextBlock Text="YOU WON!" 
-                                           FontSize="28" 
+                                <TextBlock Text="YOU WON!"
+                                           FontSize="28"
                                            FontWeight="Bold"
                                            Foreground="#1A1A1A"
                                            HorizontalAlignment="Center" />
-                                <TextBlock Text="$100 Prize" 
-                                           FontSize="18" 
+                                <TextBlock Text="$100 Prize"
+                                           FontSize="18"
                                            Foreground="#333333"
                                            HorizontalAlignment="Center" />
                             </StackPanel>
                         </Border>
                     </controls:Scratcher>
-                    
+
                     <StackPanel Orientation="Horizontal" Spacing="10">
                         <TextBlock x:Name="BasicProgressText" Text="Progress: 0%" VerticalAlignment="Center" />
                         <Button Content="Reset" Click="OnResetBasicClick" />
@@ -62,22 +60,20 @@
                     </StackPanel>
                 </StackPanel>
             </Border>
-            
+
             <!-- Colored Overlay -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" 
-                    BorderThickness="2" 
-                    Padding="15" 
-                    CornerRadius="8">
+            <Border Classes="stage"
+                    Padding="15">
                 <StackPanel Spacing="15">
-                    <TextBlock Text="Colored Gradient Overlay" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
+                    <TextBlock Text="Colored Gradient Overlay"
+                               FontSize="16"
+                               FontWeight="Bold"
                                Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="Support for linear and radial gradients in the overlay." 
+                    <TextBlock Text="Support for linear and radial gradients in the overlay."
                                Foreground="{DynamicResource SecondaryTextBrush}" />
-                    
+
                     <controls:Scratcher x:Name="GradientScratcher"
-                                        Width="300" 
+                                        Width="300"
                                         Height="150"
                                         BrushSize="50"
                                         Threshold="40"
@@ -89,81 +85,79 @@
                                 <GradientStop Offset="1" Color="#673AB7" />
                             </LinearGradientBrush>
                         </controls:Scratcher.OverlayBrush>
-                        
+
                         <Border Background="#4CAF50" CornerRadius="8">
-                            <TextBlock Text="Secret Message Revealed!" 
-                                       FontSize="20" 
+                            <TextBlock Text="Secret Message Revealed!"
+                                       FontSize="20"
                                        FontWeight="SemiBold"
                                        Foreground="White"
                                        VerticalAlignment="Center"
                                        HorizontalAlignment="Center" />
                         </Border>
                     </controls:Scratcher>
-                    
+
                     <TextBlock x:Name="GradientProgressText" Text="Progress: 0%" />
                 </StackPanel>
             </Border>
-            
+
             <!-- Different Brush Sizes -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" 
-                    BorderThickness="2" 
-                    Padding="15" 
-                    CornerRadius="8">
+            <Border Classes="stage"
+                    Padding="15">
                 <StackPanel Spacing="15">
-                    <TextBlock Text="Brush Sizes" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
+                    <TextBlock Text="Brush Sizes"
+                               FontSize="16"
+                               FontWeight="Bold"
                                Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="Compare different brush sizes: Small (20px), Medium (40px), Large (80px)" 
+                    <TextBlock Text="Compare different brush sizes: Small (20px), Medium (40px), Large (80px)"
                                Foreground="{DynamicResource SecondaryTextBrush}" />
-                    
+
                     <WrapPanel Orientation="Horizontal">
                         <StackPanel Spacing="5" Margin="0,0,20,10">
                             <TextBlock Text="Small (20px)" HorizontalAlignment="Center" FontSize="12" Opacity="0.7" />
-                            <controls:Scratcher Width="150" 
+                            <controls:Scratcher Width="150"
                                                 Height="100"
                                                 OverlayBrush="#607D8B"
                                                 BrushSize="20"
                                                 Threshold="50">
                                 <Border Background="#FF9800" CornerRadius="4">
-                                    <TextBlock Text="Prize A" 
+                                    <TextBlock Text="Prize A"
                                                Foreground="White"
-                                               VerticalAlignment="Center" 
-                                               HorizontalAlignment="Center" 
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Center"
                                                FontWeight="Bold" />
                                 </Border>
                             </controls:Scratcher>
                         </StackPanel>
-                        
+
                         <StackPanel Spacing="5" Margin="0,0,20,10">
                             <TextBlock Text="Medium (40px)" HorizontalAlignment="Center" FontSize="12" Opacity="0.7" />
-                            <controls:Scratcher Width="150" 
+                            <controls:Scratcher Width="150"
                                                 Height="100"
                                                 OverlayBrush="#455A64"
                                                 BrushSize="40"
                                                 Threshold="50">
                                 <Border Background="#03A9F4" CornerRadius="4">
-                                    <TextBlock Text="Prize B" 
+                                    <TextBlock Text="Prize B"
                                                Foreground="White"
-                                               VerticalAlignment="Center" 
-                                               HorizontalAlignment="Center" 
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Center"
                                                FontWeight="Bold" />
                                 </Border>
                             </controls:Scratcher>
                         </StackPanel>
-                        
+
                         <StackPanel Spacing="5" Margin="0,0,20,10">
                             <TextBlock Text="Large (80px)" HorizontalAlignment="Center" FontSize="12" Opacity="0.7" />
-                            <controls:Scratcher Width="150" 
+                            <controls:Scratcher Width="150"
                                                 Height="100"
                                                 OverlayBrush="#37474F"
                                                 BrushSize="80"
                                                 Threshold="50">
                                 <Border Background="#E91E63" CornerRadius="4">
-                                    <TextBlock Text="Prize C" 
+                                    <TextBlock Text="Prize C"
                                                Foreground="White"
-                                               VerticalAlignment="Center" 
-                                               HorizontalAlignment="Center" 
+                                               VerticalAlignment="Center"
+                                               HorizontalAlignment="Center"
                                                FontWeight="Bold" />
                                 </Border>
                             </controls:Scratcher>
@@ -171,48 +165,44 @@
                     </WrapPanel>
                 </StackPanel>
             </Border>
-            
+
             <!-- Threshold Example -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" 
-                    BorderThickness="2" 
-                    Padding="15" 
-                    CornerRadius="8">
+            <Border Classes="stage"
+                    Padding="15">
                 <StackPanel Spacing="15">
-                    <TextBlock Text="Threshold Detection" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
+                    <TextBlock Text="Threshold Detection"
+                               FontSize="16"
+                               FontWeight="Bold"
                                Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="The message below will appear when 70% is scratched." 
+                    <TextBlock Text="The message below will appear when 70% is scratched."
                                Foreground="{DynamicResource SecondaryTextBrush}" />
-                    
+
                     <controls:Scratcher x:Name="ThresholdScratcher"
-                                        Width="300" 
+                                        Width="300"
                                         Height="120"
                                         OverlayBrush="#795548"
                                         BrushSize="35"
                                         Threshold="70"
                                         HorizontalAlignment="Left">
                         <Border Background="#8BC34A" CornerRadius="8">
-                            <TextBlock Text="Threshold Content" 
-                                       FontSize="18" 
+                            <TextBlock Text="Threshold Content"
+                                       FontSize="18"
                                        FontWeight="SemiBold"
                                        Foreground="White"
                                        VerticalAlignment="Center"
                                        HorizontalAlignment="Center" />
                         </Border>
                     </controls:Scratcher>
-                    
-                    <TextBlock x:Name="ThresholdStatusText" 
-                               Text="Status: Scratching..." 
+
+                    <TextBlock x:Name="ThresholdStatusText"
+                               Text="Status: Scratching..."
                                FontWeight="SemiBold" />
                 </StackPanel>
             </Border>
-            
+
             <!-- Save / Restore State -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}"
-                    BorderThickness="2"
-                    Padding="15"
-                    CornerRadius="8">
+            <Border Classes="stage"
+                    Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Save / Restore State"
                                FontSize="16"
@@ -256,26 +246,24 @@
             </Border>
 
             <!-- Disabled State -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" 
-                    BorderThickness="2" 
-                    Padding="15" 
-                    CornerRadius="8">
+            <Border Classes="stage"
+                    Padding="15">
                 <StackPanel Spacing="15">
-                    <TextBlock Text="Disabled State" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
+                    <TextBlock Text="Disabled State"
+                               FontSize="16"
+                               FontWeight="Bold"
                                Foreground="{DynamicResource AccentBrush}"/>
-                    <TextBlock Text="The control cannot be scratched when disabled." 
+                    <TextBlock Text="The control cannot be scratched when disabled."
                                Foreground="{DynamicResource SecondaryTextBrush}" />
-                    
-                    <controls:Scratcher Width="300" 
+
+                    <controls:Scratcher Width="300"
                                         Height="100"
                                         IsEnabled="False"
                                         OverlayBrush="{DynamicResource ScratcherOverlayBrush}"
                                         CornerRadius="8"
                                         HorizontalAlignment="Left">
                         <Border Background="{DynamicResource CardBackgroundBrush}" CornerRadius="8">
-                            <TextBlock Text="Cannot Scratch Me" 
+                            <TextBlock Text="Cannot Scratch Me"
                                        FontSize="20"
                                        FontWeight="Bold"
                                        Foreground="White"
@@ -285,7 +273,7 @@
                     </controls:Scratcher>
                 </StackPanel>
             </Border>
-            
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/Nova.Avalonia.UI.Gallery/Views/SegmentedSliderView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/SegmentedSliderView.axaml
@@ -15,7 +15,7 @@
                  Opacity="0.6"
                  TextWrapping="Wrap"/>
 
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="12">
           <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
           <TextBlock Text="Default equal segments with continuous value selection." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -30,7 +30,7 @@
         </StackPanel>
       </Border>
 
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="12">
           <TextBlock Text="Segment Count" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
           <TextBlock Text="Use generated equal-width segments when labels are not needed." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -64,7 +64,7 @@
         </StackPanel>
       </Border>
 
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="12">
           <TextBlock Text="Custom Segments" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
           <TextBlock Text="Segments can provide labels, proportional widths, and individual brushes." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -88,7 +88,7 @@
         </StackPanel>
       </Border>
 
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="12">
           <TextBlock Text="Snapping and Read-only" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
           <TextBlock Text="IsSnapToSegmentEnabled moves drag completion to the nearest segment center; IsReadOnly keeps range values visible without pointer edits." Foreground="{DynamicResource SecondaryTextBrush}" TextWrapping="Wrap"/>
@@ -113,7 +113,7 @@
         </StackPanel>
       </Border>
 
-      <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+      <Border Classes="stage" Padding="15">
         <StackPanel Spacing="12">
           <TextBlock Text="Events" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
           <TextBlock Text="ValueChanged comes from RangeBase; SegmentChanged reports the active segment." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/ShieldView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/ShieldView.axaml
@@ -18,7 +18,7 @@
         <StackPanel Spacing="24" Margin="24">
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Basic Usage"
                                FontSize="16"
@@ -38,7 +38,7 @@
             </Border>
 
             <!-- Semantic Colors -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Semantic Colors"
                                FontSize="16"
@@ -60,7 +60,7 @@
             </Border>
 
             <!-- Custom Content -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Custom Content"
                                FontSize="16"
@@ -85,7 +85,7 @@
             </Border>
 
             <!-- Customization -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Customization"
                                FontSize="16"
@@ -105,7 +105,7 @@
             </Border>
 
             <!-- Interactivity -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Interactivity"
                                FontSize="16"
@@ -124,7 +124,7 @@
             </Border>
 
             <!-- Read-Only Mode -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Read-Only Mode"
                                FontSize="16"
@@ -144,7 +144,7 @@
             </Border>
 
             <!-- Disabled State -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="1" Padding="20" CornerRadius="8">
+            <Border Classes="stage" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Disabled State"
                                FontSize="16"

--- a/src/Nova.Avalonia.UI.Gallery/Views/ShimmerView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/ShimmerView.axaml
@@ -23,7 +23,7 @@
                       FontWeight="Bold" />
 
             <!-- Multiple TextBlocks -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Multiple TextBlocks"
                                FontWeight="Bold"
@@ -42,7 +42,7 @@
             </Border>
 
             <!-- Profile Card with Avatar -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Profile card"
                                FontWeight="Bold"
@@ -80,7 +80,7 @@
             </Border>
 
             <!-- Card with Rounded Corners -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Rounded border"
                                FontWeight="Bold"
@@ -108,7 +108,7 @@
             </Border>
 
             <!-- Complex Layout -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Complex layout"
                                FontWeight="Bold"
@@ -153,7 +153,7 @@
             </Border>
 
             <!-- List of Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="List items"
                                FontWeight="Bold"
@@ -210,7 +210,7 @@
             </Border>
 
             <!-- Buttons -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Buttons"
                                FontWeight="Bold"

--- a/src/Nova.Avalonia.UI.Gallery/Views/StaggeredPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/StaggeredPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A layout panel that positions items in a staggered grid." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items fill the column with the least height." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -32,7 +32,7 @@
             </Border>
 
             <!-- Layout Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Adjust ColumnWidth, Spacing, and Padding dynamically." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -79,7 +79,7 @@
             </Border>
 
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the layout reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/TimelinePanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/TimelinePanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A layout panel for timeline-style step/process flows." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Vertical Timeline -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Vertical Timeline" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items flow vertically with space for a connector line." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -50,7 +50,7 @@
             </Border>
 
             <!-- Alternating Timeline -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Alternating Timeline" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Items alternate left and right of the connector." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -78,7 +78,7 @@
             </Border>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -110,7 +110,7 @@
                 </StackPanel>
             </Border>
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see timeline layout reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/VariableSizeWrapPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/VariableSizeWrapPanelView.axaml
@@ -14,7 +14,7 @@
             <TextBlock Text="Windows Metro-style tile layout with variable-size tiles." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Basic Usage -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Usage" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Tiles auto-flow with ColumnSpan and RowSpan for variable sizes." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -91,7 +91,7 @@
             </Border>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Playground" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -128,7 +128,7 @@
             </Border>
 
             <!-- Dashboard Example -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dashboard Layout" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Creating a dashboard with mixed tile sizes." Foreground="{DynamicResource SecondaryTextBrush}"/>
@@ -165,7 +165,7 @@
                 </StackPanel>
             </Border>
             <!-- Dynamic Items -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Dynamic Items" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Add or remove items to see the tile grid reflow." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/VirtualizedStaggeredPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/VirtualizedStaggeredPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A staggered (masonry) panel optimized for efficiently displaying large datasets with varying item heights." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Configuration" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -40,7 +40,7 @@
             </Border>
 
             <!-- Virtualized Panel -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Large Dataset" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Scroll through 500+ items with smooth performance." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/VirtualizedVariableSizeWrapPanelView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/VirtualizedVariableSizeWrapPanelView.axaml
@@ -13,7 +13,7 @@
             <TextBlock Text="A tile grid panel optimized for efficiently displaying large datasets with variable-size tiles." Theme="{StaticResource BodyTextBlockStyle}" Opacity="0.6" TextWrapping="Wrap"/>
 
             <!-- Configuration -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Configuration" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     
@@ -40,7 +40,7 @@
             </Border>
 
             <!-- Virtualized Panel -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Large Dataset" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Scroll through 200+ tiles with varying spans." Foreground="{DynamicResource SecondaryTextBrush}"/>

--- a/src/Nova.Avalonia.UI.Gallery/Views/WatermarkView.axaml
+++ b/src/Nova.Avalonia.UI.Gallery/Views/WatermarkView.axaml
@@ -20,7 +20,7 @@
         <StackPanel Spacing="20" Margin="20">
 
             <!-- Basic Text Watermark -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Basic Text Watermark"
                                FontWeight="Bold"
@@ -46,7 +46,7 @@
             </Border>
 
             <!-- Custom Angle and Spacing -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Custom Angle and Spacing"
                                FontWeight="Bold"
@@ -78,7 +78,7 @@
             </Border>
 
             <!-- High Opacity Watermark -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Higher Opacity"
                                FontWeight="Bold"
@@ -108,7 +108,7 @@
             </Border>
 
             <!-- Interactive Playground -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="15">
                     <TextBlock Text="Interactive Playground"
                                FontWeight="Bold"
@@ -188,7 +188,7 @@
             </Border>
 
             <!-- Spaced Text -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Spaced Text"
                                FontWeight="Bold"
@@ -217,7 +217,7 @@
             </Border>
 
             <!-- Image Pattern Watermark -->
-            <Border BorderBrush="{DynamicResource AccentMutedBrush}" BorderThickness="2" Padding="15" CornerRadius="8">
+            <Border Classes="stage" Padding="15">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Image Pattern Watermark"
                                FontWeight="Bold"


### PR DESCRIPTION
Updates the gallery theming:
- Replaces the previous navigation with the current Avalonia v12 Navigation APIs.
- Uses the standard left-side navigation drawer.
- Removes the old top navigation bar.
- Keeps light and dark themes consistent across the gallery.

<img width="1882" height="1374" alt="image" src="https://github.com/user-attachments/assets/b5323465-d060-4318-879e-6700810ed0c4" />
<img width="1882" height="1384" alt="image" src="https://github.com/user-attachments/assets/48bbb1be-87e1-4a60-935c-ba8cdc9ead2a" />
